### PR TITLE
PHP 7.1 compatibility + minor cleanup

### DIFF
--- a/Model/ExtendedOrderRepository.php
+++ b/Model/ExtendedOrderRepository.php
@@ -2,6 +2,7 @@
 
 namespace MailPlus\MailPlus\Model;
 
+use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Sales\Api\Data\OrderSearchResultInterfaceFactory as SearchResultFactory;
 use Magento\Sales\Model\OrderRepository;
 use Magento\Sales\Model\ResourceModel\Metadata;
@@ -16,6 +17,11 @@ class ExtendedOrderRepository extends OrderRepository implements ExtendedOrderRe
     {
         //inject the ExtendedOrderSearchResultInterfaceFactory
         parent::__construct($metadata, $searchResultFactory);
+    }
+
+    public function getList(SearchCriteriaInterface $searchCriteria)
+    {
+        // TODO: Implement getList() method.
     }
 
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -99,4 +99,3 @@ class UpgradeSchema implements UpgradeSchemaInterface
     }
 }
 
-?>

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "OSL-3.0"
   ],
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0",
+    "php": "~5.5.0|~5.6.0|~7.0.0|7.1.0",
     "magento/magento-composer-installer": "*",
     "magento/framework": "^101.0",
     "magento/module-newsletter": "^100.0",

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
-	<acl>
-	</acl>
-</config>


### PR DESCRIPTION
Added php 7.1.0 to composer dependencies.
Added a missing  getList() method.
Removed an obsolete php closing tag.
Removed empty acl.xml