### PR TITLE
Added PHP 7.3 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "OSL-3.0"
   ],
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0",
+    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0",
     "magento/magento-composer-installer": "*",
     "magento/framework": ">=100.1.0",
     "magento/module-newsletter": ">=100.0",


### PR DESCRIPTION
We can't install the extension right now due to a composer problem.
For now we used '--ignore-platform-reqs' but thats not a solution.

`Gathering patches for root package.
Loading composer repositories with package information
Installing dependencies from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for mailplus/mailplus-connector 1.6.0 -> satisfiable by mailplus/mailplus-connector[1.6.0].
    - mailplus/mailplus-connector 1.6.0 requires php ~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0 -> your PHP version (7.3.11) does not satisfy that requirement.
`