### PR TITLE
Fix incorrect resource for webapi

### DIFF
--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -17,7 +17,7 @@
 	<route url="/V1/mailplus/orders" method="GET">
 		<service class="MailPlus\MailPlus\Api\ExtendedOrderRepositoryInterface" method="getList"/>
 		<resources>
-			<resource ref="Magento_Sales::order"/>
+			<resource ref="Magento_Sales::sales"/>
 		</resources>
 	</route>
 	<route url="/V1/mailplus/product-image/:storeId/:productId" method="GET">


### PR DESCRIPTION
The resource `Magento_Sales::order` that was used isn't a valid
resource which results in the connection to that route
(/V1/mailplus/orders) to be refused. The correct resource is
`Magento_Sales::sales` which is also used for the "normal" routes
regarding the orders.