### PR TITLE
Update composer.json to support PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "OSL-3.0"
   ],
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0",
+    "php": "~7.2.0|~7.3.0|~7.4.0",
     "magento/magento-composer-installer": "*",
     "magento/framework": ">=100.1.0",
     "magento/module-newsletter": ">=100.0",


### PR DESCRIPTION
Added PHP 7.4 and removed old PHP versions which are not supported by Magento.