### PR TITLE
Use packagist for module installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Please contact MailPlus to setup your account.
 
 - cd \<magento-folder\>
 
-- composer config repositories.mailplus vcs https://github.com/SpotlerSoftware/magento2-mailplus-connector
-
 - composer require mailplus/mailplus-connector
 
 - bin/magento module:enable MailPlus_MailPlus


### PR DESCRIPTION
This package is available via packagist. https://packagist.org/packages/mailplus/mailplus-connector